### PR TITLE
根据GitHub中的commits和issue timelines信息获取GitHub Profile信息

### DIFF
--- a/dags/dag_github_init_profiles.py
+++ b/dags/dag_github_init_profiles.py
@@ -24,15 +24,18 @@ with DAG(
 
 
     def load_github_repo_login(params):
+        print("==============================1227ConnectionTest=========================================")
         from airflow.models import Variable
         from libs.github import init_logins_for_github_profiles
+        from libs.github import init_profile_needToDo
         opensearch_conn_infos = Variable.get("opensearch_conn_data", deserialize_json=True)
         owner = params["owner"]
         repo = params["repo"]
         init_logins = init_logins_for_github_profiles.load_github_logins_by_repo(opensearch_conn_infos, owner, repo)
 
         # todo: need clean just for test
-        # do_add_updated_github_profiles = init_profiles_by_github_commits.add_updated_github_profiles(github_tokens,
+        # github_tokens = Variable.get("github_tokens", deserialize_json=True)
+        # do_add_updated_github_profiles = init_profile_needToDo.add_updated_github_profiles(github_tokens,
         # opensearch_conn_infos)
         return init_logins
 

--- a/dags/libs/github/init_issues_timeline.py
+++ b/dags/libs/github/init_issues_timeline.py
@@ -73,7 +73,7 @@ def init_sync_github_issues_timeline(github_tokens, opensearch_conn_info, owner,
                                                            ]}
                                                        }
                                                    })
-    log("DELETE github issues_timeline result:", del_result)
+    logger.info(f"DELETE github issues_timeline result:{del_result}")
 
     req_session = requests.Session()
 
@@ -81,7 +81,6 @@ def init_sync_github_issues_timeline(github_tokens, opensearch_conn_info, owner,
         number = now_item["_source"]["raw_data"]["number"]
         for page in range(1, 10000):
             time.sleep(1)
-
             req = get_github_issues_timeline(req_session, github_tokens_iter, owner, repo, number,
                                              page, since)
             one_page_github_issues_timeline = req.json()

--- a/dags/libs/github/init_logins_for_github_profiles.py
+++ b/dags/libs/github/init_logins_for_github_profiles.py
@@ -5,13 +5,13 @@ from loguru import logger
 
 # todo 抽象成类，设置全局属性
 def load_github_logins_by_repo(opensearch_conn_infos, owner, repo):
-    init_profile_logins = load_logins_by_github_commits(opensearch_conn_infos, owner, repo)
-    init_profile_logins += load_logins_by_github_issues(opensearch_conn_infos, owner, repo)
-    init_profile_logins += load_logins_by_github_issues_comments(opensearch_conn_infos, owner,
+    init_profile_logins = load_logins_by_github_issues_timeline(opensearch_conn_infos, owner,
                                                                                            repo)
-    init_profile_logins += load_logins_by_github_issues_timeline(opensearch_conn_infos, owner,
-                                                                                           repo)
-    init_profile_logins += load_logins_by_pull_requests(opensearch_conn_infos, owner, repo)
+    # init_profile_logins += load_logins_by_github_commits(opensearch_conn_infos, owner, repo)
+    # init_profile_logins += load_logins_by_github_issues(opensearch_conn_infos, owner, repo)
+    # init_profile_logins += load_logins_by_github_issues_comments(opensearch_conn_infos, owner,
+    #                                                                                        repo)
+    # init_profile_logins += load_logins_by_pull_requests(opensearch_conn_infos, owner, repo)
     return init_profile_logins
 
 

--- a/dags/libs/github/init_profile_commen.py
+++ b/dags/libs/github/init_profile_commen.py
@@ -1,4 +1,5 @@
 import copy
+from random import random
 import requests
 from opensearchpy import OpenSearch
 from ..util.base import github_headers, do_get_result, HttpGetException
@@ -67,7 +68,7 @@ def put_profile_into_opensearch(all_github_profile_users, github_tokens_iter, op
     # 获取github profile
     for github_profile_user in all_github_profile_users:
         logger.info(f'github_profile_user:{github_profile_user}')
-        time.sleep(1)
+        time.sleep(random.uniform(0.001, 0.01))
         has_user_profile = opensearch_client.search(index=OPEN_SEARCH_GITHUB_PROFILE_INDEX,
                                                     body={
                                                         "query": {

--- a/dags/libs/github/init_profile_commen.py
+++ b/dags/libs/github/init_profile_commen.py
@@ -1,5 +1,5 @@
 import copy
-from random import random
+import random 
 import requests
 from opensearchpy import OpenSearch
 from ..util.base import github_headers, do_get_result, HttpGetException
@@ -68,7 +68,7 @@ def put_profile_into_opensearch(all_github_profile_users, github_tokens_iter, op
     # 获取github profile
     for github_profile_user in all_github_profile_users:
         logger.info(f'github_profile_user:{github_profile_user}')
-        time.sleep(random.uniform(0.001, 0.01))
+        time.sleep(round(random.uniform(0.001, 0.01), 3))
         has_user_profile = opensearch_client.search(index=OPEN_SEARCH_GITHUB_PROFILE_INDEX,
                                                     body={
                                                         "query": {


### PR DESCRIPTION
1、经过对GitHub issues events和timeline events的对比分析，将获取GitHub Profile信息的信息源GitHub issues、GitHub issue comments、GitHub pull request删除，确定GitHub commits和GitHub issue timelines可以囊括所有获取GitHub Profile信息的信息源；
2、将获取GitHub Profile信息的线程休眠时间将秒级降为毫秒级。