### PR TITLE
获取github profile中airflow的dag逻辑优化

### DIFF
--- a/dags/dag_github_init_profiles.py
+++ b/dags/dag_github_init_profiles.py
@@ -1,10 +1,19 @@
-
+from airflow.utils.db import provide_session
+from airflow.models import XCom
 from datetime import datetime
 from airflow import DAG
 from airflow.operators.python import PythonOperator
 from airflow.models import Variable
-from loguru import logger
 from libs.base_dict.variable_key import NEED_INIT_GITHUB_PROFILES_REPOS
+
+
+@provide_session
+def cleanup_xcom(session=None):
+    dag_id = 'github_init_profile_v1'
+    print("===========================================testXCom")
+    print(XCom.dag_id)
+    session.query(XCom).filter(XCom.dag_id == dag_id).delete()
+
 
 with DAG(
         dag_id='github_init_profile_v1',
@@ -12,6 +21,7 @@ with DAG(
         start_date=datetime(2021, 1, 1),
         catchup=False,
         tags=['github'],
+        on_success_callback=cleanup_xcom
 ) as dag:
     def start_load_github_profile(ds, **kwargs):
         return 'End start_load_github_profile'
@@ -24,7 +34,7 @@ with DAG(
     )
 
 
-    def load_github_repo_login(params):
+    def load_github_repo_login(params, **kwargs):
         from airflow.models import Variable
         from libs.github import init_profiles
         from libs.github import sync_profiles
@@ -32,22 +42,22 @@ with DAG(
         owner = params["owner"]
         repo = params["repo"]
         init_logins = init_profiles.load_github_logins_by_repo(opensearch_conn_infos, owner, repo)
-
+        kwargs['ti'].xcom_push(key=f'{owner}_{repo}_logins', value=init_logins)
         # todo: need clean just for test
         # github_tokens = Variable.get("github_tokens", deserialize_json=True)
         # do_add_updated_github_profiles = sync_profiles.add_updated_github_profiles(github_tokens,
         # opensearch_conn_infos)
-        return init_logins
 
 
     def load_github_repo_profile(params, **kwargs):
         from airflow.models import Variable
         github_tokens = Variable.get("github_tokens", deserialize_json=True)
         opensearch_conn_infos = Variable.get("opensearch_conn_data", deserialize_json=True)
-        ti = kwargs['ti']
-        github_users_logins = ti.xcom_pull(task_ids='op_load_github_repo_login_{owner}_{repo}'.format(
-            owner=params["owner"], repo=params["repo"]))
-
+        github_users_logins =[]
+        for param in params:
+            owner = param["owner"]
+            repo = param["repo"]
+            github_users_logins += kwargs['ti'].xcom_pull(key=f'{owner}_{repo}_logins')
         from libs.github import init_profiles
         init_profiles.load_github_profiles(github_tokens=github_tokens, opensearch_conn_infos=opensearch_conn_infos,
                                            github_users_logins=github_users_logins)
@@ -56,6 +66,12 @@ with DAG(
 
     need_sync_github_profile_repos = Variable.get(NEED_INIT_GITHUB_PROFILES_REPOS, deserialize_json=True)
 
+    op_load_github_repo_profile = PythonOperator(
+        task_id='op_load_github_repo_profiles',
+        python_callable=load_github_repo_profile,
+        op_kwargs={'params': need_sync_github_profile_repos},
+        provide_context=True
+    )
     for now_need_sync_github_profile_repos in need_sync_github_profile_repos:
         op_load_github_repo_login = PythonOperator(
             task_id='op_load_github_repo_login_{owner}_{repo}'.format(
@@ -65,13 +81,4 @@ with DAG(
             op_kwargs={'params': now_need_sync_github_profile_repos},
             provide_context=True
         )
-        op_load_github_repo_profile = PythonOperator(
-            task_id='op_load_github_repo_profile_{owner}_{repo}'.format(
-                owner=now_need_sync_github_profile_repos["owner"],
-                repo=now_need_sync_github_profile_repos["repo"]),
-            python_callable=load_github_repo_profile,
-            op_kwargs={'params': now_need_sync_github_profile_repos},
-            provide_context=True
-        )
-
         op_start_load_github_profile >> op_load_github_repo_login >> op_load_github_repo_profile


### PR DESCRIPTION
获取github profile由获取所有仓库相关的logins和根据logins去重并且查询插入OS两部分构成，
之前dag运行方式为第一二步骤串行化，导致多仓库并行执行时产生异常：插入到os的profile结果不唯一；
现将在多仓库并行时，第一步并行处理后再与第二步进行串行处理，保证插入到os的profile结果唯一。