### PR TITLE
新增定时任务更新github profile两种方案

### DIFF
--- a/dags/dag_sync_github_profiles.py
+++ b/dags/dag_sync_github_profiles.py
@@ -1,0 +1,42 @@
+from datetime import datetime
+from airflow import DAG
+from airflow.operators.python import PythonOperator
+from libs.base_dict.variable_key import OPENSEARCH_CONN_DATA, GITHUB_TOKENS
+
+# v0.0.1
+
+with DAG(
+        dag_id='github_sync_profiles_v1',
+        schedule_interval=None,
+        # TODO：生产环境设定定时,更改schedule_interval的值
+        # schedule_interval='0 0 * * *',
+        start_date=datetime(2000, 1, 1),
+        catchup=False,
+        tags=['github'],
+) as dag:
+    def scheduler_sync_github_profiles(ds, **kwargs):
+        return 'End:scheduler_sync_github_profiles'
+
+
+    op_scheduler_sync_github_profiles = PythonOperator(
+        task_id='op_scheduler_sync_github_profiles',
+        python_callable=scheduler_sync_github_profiles
+    )
+
+
+    def do_sync_github_profiles():
+        from airflow.models import Variable
+        from libs.github import sync_profiles01os
+
+        github_tokens = Variable.get(GITHUB_TOKENS, deserialize_json=True)
+        opensearch_conn_infos = Variable.get(OPENSEARCH_CONN_DATA, deserialize_json=True)
+        sync_profiles01os.sync_github_profiles(github_tokens, opensearch_conn_infos)
+
+
+    op_do_sync_github_profiles = PythonOperator(
+        task_id='op_do_sync_github_profiles',
+        python_callable=do_sync_github_profiles,
+        provide_context=True,
+    )
+
+    op_scheduler_sync_github_profiles >> op_do_sync_github_profiles

--- a/dags/dag_sync_github_profiles01.py
+++ b/dags/dag_sync_github_profiles01.py
@@ -1,0 +1,47 @@
+from datetime import datetime
+from airflow import DAG
+from airflow.operators.python import PythonOperator
+from libs.base_dict.variable_key import OPENSEARCH_CONN_DATA, GITHUB_TOKENS
+from loguru import logger
+
+# v0.0.1
+
+with DAG(
+        dag_id='github_sync_profiles_v101',
+        # schedule_interval='0 0 1 * *',
+        # TODO：生产环境设定定时,更改schedule_interval的值
+        schedule_interval=None,
+        start_date=datetime(2000, 1, 1),
+        catchup=False,
+        tags=['github'],
+) as dag:
+    def scheduler_sync_github_profiles(ds, **kwargs):
+        return 'End:scheduler_sync_github_profiles'
+
+
+    op_scheduler_sync_github_profiles = PythonOperator(
+        task_id='op_scheduler_sync_github_profiles01',
+        python_callable=scheduler_sync_github_profiles
+    )
+
+
+    def do_sync_github_profiles(params):
+        from airflow.models import Variable
+        from libs.github import sync_profiles02os
+
+        github_tokens = Variable.get(GITHUB_TOKENS, deserialize_json=True)
+        opensearch_conn_infos = Variable.get(OPENSEARCH_CONN_DATA, deserialize_json=True)
+        sync_profiles02os.sync_github_profiles(github_tokens, opensearch_conn_infos, params)
+        logger.info(f"检查更新GitHub login以{params}开头的profile")
+
+
+    for i in [chr(x) for x in range(ord('a'), ord('z') + 1)]+[str(y) for y in range(9)]+\
+             [chr(x) for x in range(ord('A'), ord('Z') + 1)]:
+        op_do_sync_github_profiles = PythonOperator(
+            task_id=f'op_do_sync_github_profiles_start_with_{i}',
+            python_callable=do_sync_github_profiles,
+            op_kwargs={'params': i},
+            provide_context=True,
+        )
+
+    op_scheduler_sync_github_profiles >> op_do_sync_github_profiles

--- a/dags/libs/github/sync_profiles.py
+++ b/dags/libs/github/sync_profiles.py
@@ -42,9 +42,14 @@ def add_updated_github_profiles(github_tokens, opensearch_conn_infos):
                 "match_all": {}
             },
             "collapse": {
-                "field": "login.keyword"
+                "field": "id"
             },
             "sort": [
+                {
+                    "id": {
+                        "order": "desc"
+                    }
+                },
                 {
                     "updated_at": {
                         "order": "desc"
@@ -66,7 +71,8 @@ def add_updated_github_profiles(github_tokens, opensearch_conn_infos):
         existing_github_login = existing_github_profile["_source"]["login"]
         github_api = GithubAPI()
         session = requests.Session()
-        now_github_profile = github_api.get_github_profiles(http_session=session, github_tokens_iter=github_tokens_iter, login_info=existing_github_login)
+        now_github_profile = github_api.get_github_profiles(http_session=session, github_tokens_iter=github_tokens_iter,
+                                                            login_info=existing_github_login)
         # todo: test -->delete
         github_profile_data_source(now_github_profile)
         now_github_profile = json.dumps(now_github_profile)

--- a/dags/libs/github/sync_profiles01os.py
+++ b/dags/libs/github/sync_profiles01os.py
@@ -1,0 +1,158 @@
+import datetime
+import itertools
+import requests
+from opensearchpy import OpenSearch
+from ..util.github_api import GithubAPI
+from ..base_dict.opensearch_index import OPENSEARCH_INDEX_GITHUB_PROFILE, OPENSEARCH_INDEX_CHECK_SYNC_DATA
+from ..util.log import logger
+
+
+class SyncGithubProfilesException(Exception):
+    def __init__(self, message, status):
+        super().__init__(message, status)
+        self.message = message
+        self.status = status
+
+
+def sync_github_profiles(github_tokens,
+                         opensearch_conn_info,
+                         ):
+    print("==================================1231test=======================================")
+    github_tokens_iter = itertools.cycle(github_tokens)
+
+    opensearch_client = OpenSearch(
+        hosts=[{'host': opensearch_conn_info["HOST"], 'port': opensearch_conn_info["PORT"]}],
+        http_compress=True,
+        http_auth=(opensearch_conn_info["USER"], opensearch_conn_info["PASSWD"]),
+        use_ssl=True,
+        verify_certs=False,
+        ssl_assert_hostname=False,
+        ssl_show_warn=False
+    )
+
+    # 取得上次更新github profile 的位置
+    has_profile_check = opensearch_client.search(index=OPENSEARCH_INDEX_CHECK_SYNC_DATA,
+                                                 body={
+                                                     "size": 1,
+                                                     "track_total_hits": True,
+                                                     "query": {
+                                                         "bool": {
+                                                             "must": [
+                                                                 {
+                                                                     "term": {
+                                                                         "search_key.type.keyword": {
+                                                                             "value": "github_profiles"
+                                                                         }
+                                                                     }
+                                                                 }
+                                                             ]
+                                                         }
+                                                     },
+                                                     "sort": [
+                                                         {
+                                                             "search_key.update_timestamp": {
+                                                                 "order": "desc"
+                                                             }
+                                                         }
+                                                     ]
+                                                 }
+                                                 )
+    print("======================has_profile_check===========================")
+    print(has_profile_check)
+    existing_github_id = None
+    if len(has_profile_check["hits"]["hits"]) != 0:
+        print("=====================len(has_profile_check[\"hits\"][\"hits\"]) != 0==================================")
+        existing_github_id = has_profile_check["hits"]["hits"][0]["_source"]["github"]["id"]
+    # 将折叠（collapse）查询opensearch（去重排序）的结果作为查询更新的数据源
+    existing_github_profiles = opensearch_client.search(
+        index=OPENSEARCH_INDEX_GITHUB_PROFILE,
+        body={
+            "query": {
+                "match_all": {}
+            },
+            "collapse": {
+                "field": "id"
+            },
+            "sort": [
+                {
+                    "id": {
+                        "order": "desc"
+                    }
+                },
+                {
+                    "updated_at": {
+                        "order": "desc"
+                    }
+                }
+            ]
+        }
+    )
+    print("++++++++===============existing_github_profiles==================================")
+    print(existing_github_profiles)
+    import json
+    existing_github_profiles = json.dumps(existing_github_profiles)
+    existing_github_profiles = json.loads(existing_github_profiles)["hits"]["hits"]
+
+    next_profile_id = None
+    next_profile_login = None
+
+    for existing_github_profile in existing_github_profiles:
+        next_profile_id = existing_github_profile["_source"]["id"]
+        print("============================next_profile_id=================================")
+        print(next_profile_id)
+        if (existing_github_id is None) or (existing_github_id <= next_profile_id):
+            # 获取OpenSearch中最新的profile的"updated_at"信息
+            existing_github_profile_user_updated_at = existing_github_profile["_source"]["updated_at"]
+            # 根据上述"login"信息获取git上的profile信息中的"updated_at1"信息
+            next_profile_login = existing_github_profile["_source"]["login"]
+            github_api = GithubAPI()
+            session = requests.Session()
+            now_github_profile = github_api.get_github_profiles(http_session=session,
+                                                                github_tokens_iter=github_tokens_iter,
+                                                                login_info=next_profile_login)
+
+            now_github_profile = json.dumps(now_github_profile)
+            now_github_profile_user_updated_at = json.loads(now_github_profile)["updated_at"]
+
+            # 将获取两次的"updated_at"信息对比
+            # 一致：不作处理
+            # 不一致：将新的profile信息添加到OpenSearch中
+            if existing_github_profile_user_updated_at != now_github_profile_user_updated_at:
+                opensearch_client.index(index=OPENSEARCH_INDEX_GITHUB_PROFILE,
+                                        body=now_github_profile,
+                                        refresh=True)
+                logger.info(f"Success put updated {next_profile_login}'s github profiles into opensearch.")
+            else:
+                logger.info(f"{next_profile_login}'s github profiles of opensearch is latest.")
+    set_sync_github_profiles_check(opensearch_client=opensearch_client, login=next_profile_login, id=next_profile_id)
+
+    return "END::sync_github_profiles"
+
+
+# 建立 owner/repo github issues 更新基准
+def set_sync_github_profiles_check(opensearch_client, login, id):
+    now_time = datetime.datetime.now()
+    check_update_info = {
+        "search_key": {
+            "type": "github_profiles",
+            "update_time": now_time.strftime('%Y-%m-%dT00:00:00Z'),
+            "update_timestamp": now_time.timestamp(),
+            "login": login,
+            "id": id,
+        },
+        "github": {
+            "type": "github_profiles",
+            "login": login,
+            "id": id,
+            "profiles": {
+                "login": login,
+                "id": id,
+                "sync_datetime": now_time.strftime('%Y-%m-%dT00:00:00Z'),
+                "sync_timestamp": now_time.timestamp()
+            }
+        }
+    }
+
+    opensearch_client.index(index=OPENSEARCH_INDEX_CHECK_SYNC_DATA,
+                            body=check_update_info,
+                            refresh=True)

--- a/dags/libs/github/sync_profiles02os.py
+++ b/dags/libs/github/sync_profiles02os.py
@@ -1,0 +1,92 @@
+import datetime
+import itertools
+import requests
+from opensearchpy import OpenSearch
+from ..util.github_api import GithubAPI
+from ..base_dict.opensearch_index import OPENSEARCH_INDEX_GITHUB_PROFILE
+from ..util.log import logger
+
+
+class SyncGithubProfilesException(Exception):
+    def __init__(self, message, status):
+        super().__init__(message, status)
+        self.message = message
+        self.status = status
+
+
+def sync_github_profiles(github_tokens,
+                         opensearch_conn_info, params
+                         ):
+    github_tokens_iter = itertools.cycle(github_tokens)
+
+    opensearch_client = OpenSearch(
+        hosts=[{'host': opensearch_conn_info["HOST"], 'port': opensearch_conn_info["PORT"]}],
+        http_compress=True,
+        http_auth=(opensearch_conn_info["USER"], opensearch_conn_info["PASSWD"]),
+        use_ssl=True,
+        verify_certs=False,
+        ssl_assert_hostname=False,
+        ssl_show_warn=False
+    )
+    # 将折叠（collapse）、login的首字母未查询条件查询opensearch（去重排序）的结果作为查询更新的数据源
+    params += '*'
+    existing_github_profiles = opensearch_client.search(
+        index=OPENSEARCH_INDEX_GITHUB_PROFILE,
+        body={
+            "query": {
+                "wildcard": {
+                    "login.keyword": {
+                        "value": params
+                    }
+                }
+            },
+            "collapse": {
+                "field": "id"
+            },
+            "sort": [
+                {
+                    "id": {
+                        "order": "desc"
+                    }
+                },
+                {
+                    "updated_at": {
+                        "order": "desc"
+                    }
+                }
+            ]
+        }
+    )
+
+    if not existing_github_profiles["hits"]["hits"]:
+        return "There's no logins start with "+params[0]
+    import json
+    existing_github_profiles = json.dumps(existing_github_profiles)
+    existing_github_profiles = json.loads(existing_github_profiles)["hits"]["hits"]
+
+    for existing_github_profile in existing_github_profiles:
+        # 获取OpenSearch中最新的profile的"updated_at"信息
+        existing_github_profile_user_updated_at = existing_github_profile["_source"]["updated_at"]
+        # 根据上述"login"信息获取git上的profile信息中的"updated_at1"信息
+        now_profile_login = existing_github_profile["_source"]["login"]
+        github_api = GithubAPI()
+        session = requests.Session()
+        now_github_profile = github_api.get_github_profiles(http_session=session,
+                                                            github_tokens_iter=github_tokens_iter,
+                                                            login_info=now_profile_login)
+        now_github_profile = json.dumps(now_github_profile)
+        now_github_profile_user_updated_at = json.loads(now_github_profile)["updated_at"]
+
+        # 将获取两次的"updated_at"信息对比
+        # 一致：不作处理
+        # 不一致：将新的profile信息添加到OpenSearch中
+        if existing_github_profile_user_updated_at != now_github_profile_user_updated_at:
+            opensearch_client.index(index=OPENSEARCH_INDEX_GITHUB_PROFILE,
+                                    body=now_github_profile,
+                                    refresh=True)
+            logger.info(f"Success put updated {now_profile_login}'s github profiles into opensearch.")
+        else:
+            logger.info(f"{now_profile_login}'s github profiles of opensearch is latest.")
+
+    return "END::sync_github_profiles"
+

--- a/dags/libs/util/opensearch_api.py
+++ b/dags/libs/util/opensearch_api.py
@@ -110,6 +110,7 @@ class OpensearchAPI:
 
         return success, failed
 
+
     def put_profile_into_opensearch(self, github_logins, github_tokens_iter, opensearch_client):
         """Put GitHub user profile into opensearch if it is not in opensearch."""
 


### PR DESCRIPTION
方案一：每晚零点进行一次查询更新，从os中获取查询标志作为起始点遍历os进行信息更新，更新完将本次查询节点存入os，以备下次使用做查询标志，优点：对任务按时间进行分块处理，框架具有可复用性（只实现了全遍历查询，分块查询思路待优化和实现）；
方案二：每月一日的零点进行一次全遍历查询更新，将login首位模糊查询作为循环依据,优点：可以根据对login进行模糊查询分类多节点并行处理任务（已实现，但节点过多，影响待测试）。